### PR TITLE
[main < update-extension-to-2.9] Update Docker Extension so that it uses Memgraph Platform 2.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE?=memgraph/memgraph-docker-extension
-TAG?=2.8.1
+TAG?=2.9.0
 
 BUILDER=buildx-multi-arch
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   memgraph-platform:
-    image: "memgraph/memgraph-platform:2.8.0-memgraph2.8.0-lab2.6.0-mage1.7"
+    image: "memgraph/memgraph-platform:2.9.0-memgraph2.9.0-lab2.7.1-mage1.8
     ports:
       - "7687:7687"
       - "3000:3000"


### PR DESCRIPTION
I've updated the Docker Extension so that it uses Memgraph Platform 2.9 now.